### PR TITLE
First integration with the gem personnummer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,7 @@ GEM
       activerecord (>= 4.0, < 5.2)
     parser (2.5.0.5)
       ast (~> 2.4.0)
+    personnummer (0.1.0)
     pg (0.21.0)
     pg_search (2.0.1)
       activerecord (>= 4.2)
@@ -562,6 +563,7 @@ DEPENDENCIES
   omniauth-twitter (~> 1.4.0)
   paperclip (~> 5.2.1)
   paranoia (~> 2.4.0)
+  personnummer
   pg (~> 0.21.0)
   pg_search (~> 2.0.1)
   puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,14 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (8.2.0)
       execjs
+    aws-sdk (2.11.101)
+      aws-sdk-resources (= 2.11.101)
+    aws-sdk-core (2.11.101)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.11.101)
+      aws-sdk-core (= 2.11.101)
+    aws-sigv4 (1.0.3)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -217,6 +225,7 @@ GEM
       railties (>= 3.1, < 6.0)
     invisible_captcha (0.10.0)
       rails (>= 3.2.0)
+    jmespath (1.4.0)
     jquery-fileupload-rails (0.4.7)
       actionpack (>= 3.1)
       railties (>= 3.1)
@@ -327,7 +336,7 @@ GEM
       arel (>= 6)
     powerpack (0.1.1)
     public_suffix (3.0.1)
-    puma (3.11.4)
+    puma (3.12.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.10)
@@ -513,6 +522,7 @@ DEPENDENCIES
   ahoy_matey (~> 1.6.0)
   ancestry (~> 3.0.1)
   autoprefixer-rails (~> 8.2.0)
+  aws-sdk (~> 2)
   browser (~> 2.5.2)
   bullet (~> 5.7.0)
   byebug (~> 10.0.0)
@@ -544,7 +554,7 @@ DEPENDENCIES
   graphiql-rails (~> 1.4.1)
   graphql (~> 1.7.8)
   groupdate (~> 3.2.0)
-  heroku-deflater
+  heroku-deflater (~> 0.6.3)
   i18n-tasks (~> 0.9.20)
   initialjs-rails (~> 0.2.0.5)
   invisible_captcha (~> 0.10.0)
@@ -566,7 +576,7 @@ DEPENDENCIES
   personnummer
   pg (~> 0.21.0)
   pg_search (~> 2.0.1)
-  puma
+  puma (~> 3.12.0)
   quiet_assets (~> 1.1.0)
   rails (= 4.2.10)
   rails-assets-leaflet!

--- a/Gemfile_custom
+++ b/Gemfile_custom
@@ -4,10 +4,12 @@
 # * Spanish: https://github.com/consul/consul/blob/master/CUSTOMIZE_ES.md#gemfile
 #
 
-gem 'puma'
+gem 'puma', '~> 3.12.0'
+gem 'aws-sdk', '~> 2'
 #gem 'rack-timeout'
 gem 'rails_12factor', :group => :production
-gem 'heroku-deflater', :group => :production
+
+gem 'heroku-deflater', '~> 0.6.3', :group => :production
 gem 'personnummer'
 
 group :test do

--- a/Gemfile_custom
+++ b/Gemfile_custom
@@ -8,6 +8,7 @@ gem 'puma'
 #gem 'rack-timeout'
 gem 'rails_12factor', :group => :production
 gem 'heroku-deflater', :group => :production
+gem 'personnummer'
 
 group :test do
   gem 'fuubar'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
@@ -78,4 +78,16 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Paperclip settings to store images and documents on S3
+  config.paperclip_defaults = {
+    :storage => :s3,
+    :s3_region => ENV['AWS_REGION'],
+    :s3_credentials => {
+      :s3_host_name => ENV["AWS_S3_HOST_NAME"],
+      :bucket => ENV['AWS_BUCKET'],
+      :access_key_id => ENV['AWS_ACCESS_KEY_ID'],
+      :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
+    }
+  }
 end

--- a/config/locales/custom/en/activerecord.yml
+++ b/config/locales/custom/en/activerecord.yml
@@ -1,0 +1,5 @@
+en:
+  activerecord:
+    attributes:
+      user:
+        login: "Email or username or personal number"

--- a/config/locales/custom/en/devise_views.yml
+++ b/config/locales/custom/en/devise_views.yml
@@ -1,0 +1,5 @@
+en:
+  devise_views:
+    sessions:
+      new:
+        login_label: Email or username or personal number

--- a/config/locales/custom/en/verification.yml
+++ b/config/locales/custom/en/verification.yml
@@ -1,0 +1,7 @@
+sv:
+  verification:
+    residence:
+      new:
+        document_number_help_text_html: '<strong>Personnummer</strong>: 199206239176<br> <strong>Pass</strong>: AAA000001<br> <strong>Övrig identitetshandling</strong>: X1234567P'
+        document_type:
+          spanish_id: Personnummer

--- a/config/locales/custom/sv/activerecord.yml
+++ b/config/locales/custom/sv/activerecord.yml
@@ -1,0 +1,5 @@
+sv:
+  activerecord:
+    attributes:
+      user:
+        login: "E-post eller användarnamn eller personnummer"

--- a/config/locales/custom/sv/devise_views.yml
+++ b/config/locales/custom/sv/devise_views.yml
@@ -1,0 +1,5 @@
+sv:
+  devise_views:
+    sessions:
+      new:
+        login_label: "E-post eller användarnamn eller personnummer"

--- a/config/locales/custom/sv/verification.yml
+++ b/config/locales/custom/sv/verification.yml
@@ -1,0 +1,7 @@
+en:
+  verification:
+    residence:
+      new:
+        document_number_help_text_html: '<strong>Personal Number</strong>: 199206239176<br> <strong>Passport</strong>: AAA000001<br> <strong>Residence card</strong>: X1234567P'
+        document_type:
+          spanish_id: Personal number

--- a/lib/census_caller.rb
+++ b/lib/census_caller.rb
@@ -3,6 +3,7 @@ class CensusCaller
   def call(document_type, document_number)
     response = CensusApi.new.call(document_type, document_number)
     response = LocalCensus.new.call(document_type, document_number) unless response.valid?
+    response = PersonnummerApi.new.call(document_type, document_number) unless response.valid?
 
     response
   end

--- a/lib/personnummer_api.rb
+++ b/lib/personnummer_api.rb
@@ -1,0 +1,50 @@
+class PersonnummerApi
+
+  def call(document_type, document_number)
+    Response.new(document_type, document_number)
+  end
+
+  class Response
+    def initialize(document_type, document_number)
+      @document_type = document_type
+      @document_number = document_number
+      if personnummer?
+        @personnummer = Personnummer.new(document_number)
+      end
+    end
+
+    def valid?
+      if personnummer?
+        @personnummer.valid?
+      else
+        true
+      end
+    end
+
+    def date_of_birth
+      if personnummer?
+        @personnummer.born
+      else
+        nil
+      end
+    end
+
+    def region
+      @personnummer.region
+    end
+
+    def gender
+      if @personnummer.female?
+        "female"
+      else
+        "male"
+      end
+    end
+
+    private
+
+      def personnummer?
+        @document_type.to_s == "1"
+      end
+  end
+end

--- a/lib/personnummer_api.rb
+++ b/lib/personnummer_api.rb
@@ -9,20 +9,22 @@ class PersonnummerApi
       @document_type = document_type
       @document_number = document_number
       if personnummer?
-        @personnummer = Personnummer.new(document_number)
+        begin
+          @personnummer = Personnummer.new(document_number)
+        end
       end
     end
 
     def valid?
       if personnummer?
-        @personnummer.valid?
+        valid_personnummer?
       else
         true
       end
     end
 
     def date_of_birth
-      if personnummer?
+      if valid_personnummer?
         @personnummer.born
       else
         nil
@@ -30,14 +32,22 @@ class PersonnummerApi
     end
 
     def region
-      @personnummer.region
+      if valid_personnummer?
+        @personnummer.region
+      else
+        nil
+      end
     end
 
     def gender
-      if @personnummer.female?
-        "female"
+      if valid_personnummer?
+        if @personnummer.female?
+          "female"
+        else
+          "male"
+        end
       else
-        "male"
+        nil
       end
     end
 
@@ -45,6 +55,10 @@ class PersonnummerApi
 
       def personnummer?
         @document_type.to_s == "1"
+      end
+
+      def valid_personnummer?
+        personnummer? && @personnummer != nil && @personnummer.valid?
       end
   end
 end

--- a/spec/features/custom/users_auth_spec.rb
+++ b/spec/features/custom/users_auth_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+feature 'Users' do
+
+  context 'Regular authentication' do
+
+    context 'Sign in' do
+
+      scenario 'with short personal number' do
+        create(:user, email: 'manuela@consul.dev', document_type: '1',
+          document_number: '9305249170', password: 'judgementday')
+
+        visit '/'
+        click_link 'Sign in'
+        fill_in 'user_login',    with: '9305249170'
+        fill_in 'user_password', with: 'judgementday'
+        click_button 'Enter'
+
+        expect(page).to have_content 'You have been signed in successfully.'
+      end
+
+      scenario 'with long personal number' do
+        create(:user, email: 'manuela@consul.dev', document_type: '1',
+          document_number: '9305249170', password: 'judgementday')
+
+        visit '/'
+        click_link 'Sign in'
+        fill_in 'user_login',    with: '199305249170'
+        fill_in 'user_password', with: 'judgementday'
+        click_button 'Enter'
+
+        expect(page).to have_content 'You have been signed in successfully.'
+      end
+
+      scenario 'with long hyphenated personal number' do
+        create(:user, email: 'manuela@consul.dev', document_type: '1',
+          document_number: '9305249170', password: 'judgementday')
+
+        visit '/'
+        click_link 'Sign in'
+        fill_in 'user_login',    with: '19930524-9170'
+        fill_in 'user_password', with: 'judgementday'
+        click_button 'Enter'
+
+        expect(page).to have_content 'You have been signed in successfully.'
+      end
+
+      scenario 'with incomplete personal number' do
+        create(:user, email: 'manuela@consul.dev', document_type: '1',
+          document_number: '9305249170', password: 'judgementday')
+
+        visit '/'
+        click_link 'Sign in'
+        fill_in 'user_login',    with: '930524917'
+        fill_in 'user_password', with: 'judgementday'
+        click_button 'Enter'
+
+        expect(page).to have_content 'Invalid login or password'
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
References
===================
#12
#1 
#2 

Objectives
===================
- [x] Allow managers to log in people and create accounts for them with their personal number
- [x] Check that the personal number is correct according to the Swedish standards thanks to the gem [c7/personnummer](https://github.com/c7/personnummer)
- [x] Allow users to log in with their personal number from the normal interface
- [ ] Allow users to verify their account by adding their personal number
- [ ] Modify the interface texts to reflect these changes

Visual Changes
===================
- [x] Login window displays that the user can login with its personal number
- [x] Management window offers to choose "Personnummer" as a type of document
- [ ] Success and error messages correctly reflect these changes
- [ ] User verification process allows to choose "Personnummer" as a type of document
- [ ] Help pages

Notes
===================
- No check to SPAR yet