### PR TITLE
Add fields for age and gender at registration

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -62,6 +62,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       params[:user].delete(:redeemable_code) if params[:user].present? && params[:user][:redeemable_code].blank?
       params.require(:user).permit(:username, :email, :password,
                                    :password_confirmation, :terms_of_service, :locale,
+                                   :gender, :date_of_birth,
                                    :redeemable_code)
     end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -69,4 +69,13 @@ module UsersHelper
       t("account.show.public_interests_user_title_list")
     end
   end
+
+  def gender_select_options
+    [
+      ["", nil],
+      [t("devise_views.users.registrations.new.demographics_gender.female"), "female"],
+      [t("devise_views.users.registrations.new.demographics_gender.male"), "male"],
+      [t("devise_views.users.registrations.new.demographics_gender.other"), "other"]
+    ]
+  end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -100,6 +100,7 @@ class Setting < ApplicationRecord
         "feature.remote_census": nil,
         "feature.valuation_comment_notification": true,
         "feature.graphql_api": true,
+        "feature.registration.demographics": false,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,
         "homepage.widgets.feeds.proposals": true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,6 +103,7 @@ class User < ApplicationRecord
   scope :officials,      -> { where("official_level > 0") }
   scope :male,           -> { where(gender: "male") }
   scope :female,         -> { where(gender: "female") }
+  scope :other,          -> { where(gender: "other") }
   scope :newsletter,     -> { where(newsletter: true) }
   scope :for_render,     -> { includes(:organization) }
   scope :by_document,    ->(document_type, document_number) do

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -36,6 +36,25 @@
         <%= f.text_field :redeemable_code, placeholder: t("devise_views.users.registrations.new.redeemable_code") %>
       <% end %>
 
+      <% if feature?("registration.demographics") %>
+
+      <div class="small-12 column auth-divider">
+        <span><%= t("devise_views.users.registrations.new.demographics_separator") %></span>
+      </div>
+
+      <%= f.select :gender, gender_select_options,
+                   label: t("devise_views.users.registrations.new.demographics_gender.title")%>
+      <div class="date-of-birth">
+        <%= f.date_select :date_of_birth,
+                          prompt: true,
+                          discard_day: true,
+                          discard_month: true,
+                          start_year: 1900, end_year: 1.year.ago.year,
+                          label: t("devise_views.users.registrations.new.demographics_year") %>
+      </div>
+
+      <% end %>
+
       <%= f.check_box :terms_of_service,
         title: t("devise_views.users.registrations.new.terms_title"),
         label: t("devise_views.users.registrations.new.terms",

--- a/config/locales/en/devise_views.yml
+++ b/config/locales/en/devise_views.yml
@@ -106,6 +106,13 @@ en:
           waiting_for: "Awaiting confirmation of:"
         new:
           cancel: Cancel login
+          demographics_separator: Help us to know who participates (optional)
+          demographics_gender:
+            title: Gender
+            female: Female
+            male: Male
+            other: Other
+          demographics_year: Year of birth
           email_label: Email
           organization_signup: Do you represent an organisation or collective? %{signup_link}
           organization_signup_link: Sign up here

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -91,6 +91,9 @@ en:
       google_login_description: "Allow users to sign up with their Google Account"
       featured_proposals: "Featured proposals"
       featured_proposals_description: "Shows featured proposals on index proposals page"
+      registration:
+        demographics: Demographics at sign up
+        demographics_description: Asks for gender and year of birth at sign up
       signature_sheets: "Signature sheets"
       signature_sheets_description: "It allows adding from the Administration panel signatures collected on-site to Proposals and investment projects of the Participative Budgets"
       user:

--- a/config/locales/sv-SE/devise_views.yml
+++ b/config/locales/sv-SE/devise_views.yml
@@ -106,6 +106,13 @@ sv:
           waiting_for: "Väntar på bekräftelse av:"
         new:
           cancel: Avbryt inloggning
+          demographics_separator: Hjälp oss att veta vem deltar (frivilligt)
+          demographics_gender:
+            title: Kön
+            female: Kvinna
+            male: Man
+            other: Annat
+          demographics_year: Födelseår
           email_label: E-post
           organization_signup: Representerar du en organisation eller grupp? %{signup_link}
           organization_signup_link: Registrera dig här

--- a/config/locales/sv-SE/settings.yml
+++ b/config/locales/sv-SE/settings.yml
@@ -35,6 +35,9 @@ sv:
       twitter_login: "Twitter-inloggning"
       facebook_login: "Facebook-inloggning"
       google_login: "Google-inloggning"
+      registration:
+        demographics: Demografisk under registrering
+        demographics_description: Tillåter användaren att skriva in sin födelseår och kön under registrering
       signature_sheets: "Namninsamlingar"
       spending_proposals: "Investeringsförslag"
       user:


### PR DESCRIPTION
## Objectives

Consul doesn't ask for demographic information at registration, it gets them at verification by checking with the census API.

This PR asks for age and gender at registration when there is no verification (or no access to a census with demographic info).

## Visual Changes

![Capture d’écran 2019-11-26 à 15 35 07](https://user-images.githubusercontent.com/7223028/69643123-23ffe100-1063-11ea-9440-8c042c7584ff.png)

## Notes

- You might need to add a setting `feature.registration.demographics` directly in the settings in the database on an existing installation.